### PR TITLE
MIDI controller numbers can be 0-127

### DIFF
--- a/adafruit_midi.py
+++ b/adafruit_midi.py
@@ -119,7 +119,7 @@ class MIDI:
     def control_change(self, control, value, channel=None):
         """Sends a MIDI CC message.
 
-        :param int control: The controller number. Must be 0-15.
+        :param int control: The controller number. Must be 0-127.
         :param int value: The control value. Must be 0-127.
 
         """


### PR DESCRIPTION
The original documentation state controller numbers must be 0-15, but it's actually 0-127 for MIDI. There are many controllers in MIDI that are 14-bit and are made up of two packets of 7-bits, one MSB, one LSB. For example, controller 20 is the MSB and controller 52 is the LSB.