### PR TITLE
Removes the usb-midi package from the requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,7 @@ setup(
     author='Adafruit Industries',
     author_email='circuitpython@adafruit.com',
 
-    install_requires=['Adafruit-Blinka',
-                      'usb-midi'],
+    install_requires=['Adafruit-Blinka'],
 
     # Choose your license
     license='MIT',


### PR DESCRIPTION
usb-midi is built into Circuitpython and it not a separate package to install

fixes #18 