### PR TITLE
Added continue system message

### DIFF
--- a/adafruit_midi/midi_continue.py
+++ b/adafruit_midi/midi_continue.py
@@ -1,0 +1,49 @@
+# The MIT License (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""
+`adafruit_midi.continue`
+================================================================================
+
+Continue MIDI message.
+
+
+* Author(s): Mark Komus
+
+Implementation Notes
+--------------------
+
+"""
+
+from .midi_message import MIDIMessage
+
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_MIDI.git"
+
+
+class Continue(MIDIMessage):
+    """Continue MIDI message.
+    """
+
+    _STATUS = 0xFB
+    _STATUSMASK = 0xFF
+    LENGTH = 1
+
+
+Continue.register_message_type()


### PR DESCRIPTION
Was looking into MIDI and saw Issue #23 that the Continue message was missing. Added it in. Tested it again Waveform (seeing Start, Stop and now Continue as well when I Play/Pause/Resume).