### PR TITLE
Address pylint diagnostic 'consider using a generator'

### DIFF
--- a/examples/midi_inoutdemo.py
+++ b/examples/midi_inoutdemo.py
@@ -36,7 +36,7 @@ print("Midi Demo in and out")
 
 # Convert channel numbers at the presentation layer to the ones musicians use
 print("Default output channel:", midi.out_channel + 1)
-print("Listening on input channels:", tuple([c + 1 for c in midi.in_channel]))
+print("Listening on input channels:", tuple(c + 1 for c in midi.in_channel))
 
 major_chord = [0, 4, 7]
 while True:


### PR DESCRIPTION
In https://github.com/adafruit/Adafruit_CircuitPython_MIDI/pull/38 there was an unrelated pylint diagnostic:
```
examples/midi_inoutdemo.py:39:38: R1728: Consider using a generator instead 'tuple(c + 1 for c in midi.in_channel)' (consider-using-generator)
```

Do so.