### PR TITLE
Fix pylint errors

### DIFF
--- a/adafruit_midi/__init__.py
+++ b/adafruit_midi/__init__.py
@@ -158,7 +158,9 @@ class MIDI:
             data = bytearray()
             for each_msg in msg:
                 each_msg.channel = channel
-                data.extend(each_msg.__bytes__())  # pylint: disable=unnecessary-dunder-call
+                data.extend(
+                    each_msg.__bytes__()  # pylint: disable=unnecessary-dunder-call
+                )
 
         self._send(data, len(data))
 

--- a/adafruit_midi/__init__.py
+++ b/adafruit_midi/__init__.py
@@ -152,12 +152,13 @@ class MIDI:
             channel = self.out_channel
         if isinstance(msg, MIDIMessage):
             msg.channel = channel
-            data = msg.__bytes__()  # bytes(object) does not work in uPy
+            # bytes(object) does not work in uPy
+            data = msg.__bytes__()  # pylint: disable=unnecessary-dunder-call
         else:
             data = bytearray()
             for each_msg in msg:
                 each_msg.channel = channel
-                data.extend(each_msg.__bytes__())
+                data.extend(each_msg.__bytes__())  # pylint: disable=unnecessary-dunder-call
 
         self._send(data, len(data))
 

--- a/tests/test_MIDIMessage_unittests.py
+++ b/tests/test_MIDIMessage_unittests.py
@@ -1,8 +1,8 @@
-# pylint: disable=invalid-name
 # SPDX-FileCopyrightText: 2019 Kevin J. Walters for Adafruit Industries
 #
 # SPDX-License-Identifier: MIT
-# pylint: enable=invalid-name
+
+# pylint: disable=invalid-name
 
 import unittest
 

--- a/tests/test_MIDIMessage_unittests.py
+++ b/tests/test_MIDIMessage_unittests.py
@@ -32,9 +32,7 @@ from adafruit_midi.system_exclusive import SystemExclusive
 
 # pylint: disable=invalid-name
 class Test_MIDIMessage_from_message_byte_tests(unittest.TestCase):
-    # pylint: enable=invalid-name
     def test_NoteOn_basic(self):  # pylint: disable=invalid-name
-        # pylint: enable=invalid-name
         data = bytes([0x90, 0x30, 0x7F])
         ichannel = 0
 
@@ -50,7 +48,6 @@ class Test_MIDIMessage_from_message_byte_tests(unittest.TestCase):
         self.assertEqual(msg.channel, 0)
 
     def test_NoteOn_awaitingthirdbyte(self):  # pylint: disable=invalid-name
-        # pylint: enable=invalid-name
         data = bytes([0x90, 0x30])
         ichannel = 0
 
@@ -71,7 +68,6 @@ class Test_MIDIMessage_from_message_byte_tests(unittest.TestCase):
         self.assertEqual(skipped, 0)
 
     def test_NoteOn_predatajunk(self):  # pylint: disable=invalid-name
-        # pylint: enable=invalid-name
         data = bytes([0x20, 0x64, 0x90, 0x30, 0x32])
         ichannel = 0
 
@@ -91,7 +87,6 @@ class Test_MIDIMessage_from_message_byte_tests(unittest.TestCase):
         self.assertEqual(msg.channel, 0)
 
     def test_NoteOn_prepartialsysex(self):  # pylint: disable=invalid-name
-        # pylint: enable=invalid-name
         data = bytes([0x01, 0x02, 0x03, 0x04, 0xF7, 0x90, 0x30, 0x32])
         ichannel = 0
 
@@ -128,7 +123,6 @@ class Test_MIDIMessage_from_message_byte_tests(unittest.TestCase):
         self.assertEqual(msg.channel, 0)
 
     def test_NoteOn_postNoteOn(self):  # pylint: disable=invalid-name
-        # pylint: enable=invalid-name
         data = bytes([0x90 | 0x08, 0x30, 0x7F, 0x90 | 0x08, 0x37, 0x64])
         ichannel = 8
 
@@ -144,7 +138,6 @@ class Test_MIDIMessage_from_message_byte_tests(unittest.TestCase):
         self.assertEqual(msg.channel, 8)
 
     def test_NoteOn_postpartialNoteOn(self):  # pylint: disable=invalid-name
-        # pylint: enable=invalid-name
         data = bytes([0x90, 0x30, 0x7F, 0x90, 0x37])
         ichannel = 0
 
@@ -160,7 +153,6 @@ class Test_MIDIMessage_from_message_byte_tests(unittest.TestCase):
         self.assertEqual(msg.channel, 0)
 
     def test_NoteOn_preotherchannel(self):  # pylint: disable=invalid-name
-        # pylint: enable=invalid-name
         data = bytes([0x90 | 0x05, 0x30, 0x7F, 0x90 | 0x03, 0x37, 0x64])
         ichannel = 3
 
@@ -175,10 +167,9 @@ class Test_MIDIMessage_from_message_byte_tests(unittest.TestCase):
         self.assertEqual(skipped, 0)
         self.assertEqual(msg.channel, 3)
 
-    def test_NoteOn_preotherchannelplusintermediatejunk(
+    def test_NoteOn_preotherchannelplusintermediatejunk(  # pylint: disable=invalid-name
         self,
-    ):  # pylint: disable=invalid-name
-        # pylint: enable=invalid-name
+    ):
         data = bytes([0x90 | 0x05, 0x30, 0x7F, 0x00, 0x00, 0x90 | 0x03, 0x37, 0x64])
         ichannel = 3
 
@@ -196,7 +187,6 @@ class Test_MIDIMessage_from_message_byte_tests(unittest.TestCase):
         self.assertEqual(msg.channel, 3)
 
     def test_NoteOn_wrongchannel(self):  # pylint: disable=invalid-name
-        # pylint: enable=invalid-name
         data = bytes([0x95, 0x30, 0x7F])
         ichannel = 3
 
@@ -209,7 +199,6 @@ class Test_MIDIMessage_from_message_byte_tests(unittest.TestCase):
         self.assertEqual(skipped, 0)
 
     def test_NoteOn_partialandpreotherchannel1(self):  # pylint: disable=invalid-name
-        # pylint: enable=invalid-name
         data = bytes([0x95, 0x30, 0x7F, 0x93])
         ichannel = 3
 
@@ -224,7 +213,6 @@ class Test_MIDIMessage_from_message_byte_tests(unittest.TestCase):
         self.assertEqual(skipped, 0)
 
     def test_NoteOn_partialandpreotherchannel2(self):  # pylint: disable=invalid-name
-        # pylint: enable=invalid-name
         data = bytes([0x95, 0x30, 0x7F, 0x93, 0x37])
         ichannel = 3
 
@@ -239,7 +227,6 @@ class Test_MIDIMessage_from_message_byte_tests(unittest.TestCase):
         self.assertEqual(skipped, 0)
 
     def test_NoteOn_constructor_int(self):  # pylint: disable=invalid-name
-        # pylint: enable=invalid-name
         object1 = NoteOn(60, 0x7F)
 
         self.assertEqual(object1.note, 60)
@@ -265,7 +252,6 @@ class Test_MIDIMessage_from_message_byte_tests(unittest.TestCase):
         self.assertIsNone(object4.channel)
 
     def test_SystemExclusive_NoteOn(self):  # pylint: disable=invalid-name
-        # pylint: enable=invalid-name
         data = bytes([0xF0, 0x42, 0x01, 0x02, 0x03, 0x04, 0xF7, 0x90 | 14, 0x30, 0x60])
         ichannel = 14
 
@@ -293,10 +279,9 @@ class Test_MIDIMessage_from_message_byte_tests(unittest.TestCase):
         self.assertEqual(skipped, 0)
         self.assertEqual(msg.channel, 14)
 
-    def test_SystemExclusive_NoteOn_premalterminatedsysex(
+    def test_SystemExclusive_NoteOn_premalterminatedsysex(  # pylint: disable=invalid-name
         self,
-    ):  # pylint: disable=invalid-name
-        # pylint: enable=invalid-name
+    ):
         data = bytes([0xF0, 0x42, 0x01, 0x02, 0x03, 0x04, 0xF0, 0x90, 0x30, 0x32])
         ichannel = 0
 
@@ -312,7 +297,6 @@ class Test_MIDIMessage_from_message_byte_tests(unittest.TestCase):
         )
 
     def test_Unknown_SinglebyteStatus(self):  # pylint: disable=invalid-name
-        # pylint: enable=invalid-name
         data = bytes([0xFD])
         ichannel = 0
 
@@ -326,7 +310,6 @@ class Test_MIDIMessage_from_message_byte_tests(unittest.TestCase):
         self.assertIsNone(msg.channel)
 
     def test_Empty(self):  # pylint: disable=invalid-name
-        # pylint: enable=invalid-name
         data = bytes([])
         ichannel = 0
 
@@ -343,7 +326,6 @@ class Test_MIDIMessage_NoteOn_constructor(
     unittest.TestCase
 ):  # pylint: disable=invalid-name
     def test_NoteOn_constructor_string(self):  # pylint: disable=invalid-name
-        # pylint: enable=invalid-name
         object1 = NoteOn("C4", 0x64)
         self.assertEqual(object1.note, 60)
         self.assertEqual(object1.velocity, 0x64)
@@ -369,7 +351,6 @@ class Test_MIDIMessage_NoteOn_constructor(
             NoteOn(128, 0x7F)
 
     def test_NoteOn_constructor_upperrange1(self):  # pylint: disable=invalid-name
-        # pylint: enable=invalid-name
         object1 = NoteOn("G9", 0x7F)
         self.assertEqual(object1.note, 127)
         self.assertEqual(object1.velocity, 0x7F)
@@ -383,12 +364,11 @@ class Test_MIDIMessage_NoteOn_constructor(
             NoteOn("CC4", 0x7F)
 
 
-class Test_MIDIMessage_NoteOff_constructor(
+class Test_MIDIMessage_NoteOff_constructor(  # pylint: disable=invalid-name
     unittest.TestCase
-):  # pylint: disable=invalid-name
+):
     # mostly cut and paste from NoteOn above
     def test_NoteOff_constructor_string(self):  # pylint: disable=invalid-name
-        # pylint: enable=invalid-name
         object1 = NoteOff("C4", 0x64)
         self.assertEqual(object1.note, 60)
         self.assertEqual(object1.velocity, 0x64)
@@ -418,7 +398,6 @@ class Test_MIDIMessage_NoteOff_constructor(
             NoteOff(128, 0x7F)
 
     def test_NoteOff_constructor_upperrange1(self):  # pylint: disable=invalid-name
-        # pylint: enable=invalid-name
         object1 = NoteOff("G9", 0x7F)
         self.assertEqual(object1.note, 127)
         self.assertEqual(object1.velocity, 0x7F)

--- a/tests/test_MIDI_unittests.py
+++ b/tests/test_MIDI_unittests.py
@@ -184,7 +184,7 @@ class Test_MIDI(unittest.TestCase):
         ) + bytes(NoteOn("C5", 0x7F, channel=channel))
         midi = MIDI_mocked_receive(channel, raw_data, [2, 2, 1, 1, 3])
 
-        for unused in range(4):  # pylint: disable=unused-variable
+        for _ in range(4):
             msg = midi.receive()
             self.assertIsInstance(msg, adafruit_midi.midi_message.MIDIUnknownEvent)
             self.assertIsNone(msg.channel)

--- a/tests/test_MIDI_unittests.py
+++ b/tests/test_MIDI_unittests.py
@@ -1,8 +1,8 @@
-# pylint: disable=invalid-name
 # SPDX-FileCopyrightText: 2019 Kevin J. Walters for Adafruit Industries
 #
 # SPDX-License-Identifier: MIT
-# pylint: enable=invalid-name
+
+# pylint: disable=invalid-name
 
 import unittest
 from unittest.mock import Mock, call

--- a/tests/test_MIDI_unittests.py
+++ b/tests/test_MIDI_unittests.py
@@ -37,7 +37,6 @@ import adafruit_midi
 
 # For loopback/echo tests
 def MIDI_mocked_both_loopback(in_c, out_c):  # pylint: disable=invalid-name
-    # pylint: enable=invalid-name
     usb_data = bytearray()
 
     def write(buffer, length):
@@ -61,7 +60,6 @@ def MIDI_mocked_both_loopback(in_c, out_c):  # pylint: disable=invalid-name
 
 
 def MIDI_mocked_receive(in_c, data, read_sizes):  # pylint: disable=invalid-name
-    # pylint: enable=invalid-name
     usb_data = bytearray(data)
     chunks = read_sizes
     chunk_idx = 0
@@ -101,7 +99,6 @@ class Test_MIDI_constructor(unittest.TestCase):  # pylint: disable=invalid-name
 class Test_MIDI(unittest.TestCase):
     # pylint: disable=too-many-branches
     def test_captured_data_one_byte_reads(self):  # pylint: disable=invalid-name
-        # pylint: enable=invalid-name
         channel = 0
         # From an M-Audio AXIOM controller
         raw_data = bytearray(
@@ -173,7 +170,6 @@ class Test_MIDI(unittest.TestCase):
             self.assertIsNone(msg)
 
     def test_unknown_before_NoteOn(self):  # pylint: disable=invalid-name
-        # pylint: enable=invalid-name
         channel = 0
         # From an M-Audio AXIOM controller
         raw_data = bytes(
@@ -197,7 +193,6 @@ class Test_MIDI(unittest.TestCase):
 
     # See https://github.com/adafruit/Adafruit_CircuitPython_MIDI/issues/8
     def test_running_status_when_implemented(self):  # pylint: disable=invalid-name
-        # pylint: enable=invalid-name
         channel = 8
         raw_data = (
             bytes(NoteOn("C5", 0x7F, channel=channel))
@@ -210,7 +205,6 @@ class Test_MIDI(unittest.TestCase):
         # self.assertEqual(TOFINISH, WHENIMPLEMENTED)
 
     def test_somegood_somemissing_databytes(self):  # pylint: disable=invalid-name
-        # pylint: enable=invalid-name
         channel = 8
         raw_data = (
             bytes(NoteOn("C5", 0x7F, channel=channel))
@@ -468,7 +462,6 @@ class Test_MIDI_send(unittest.TestCase):
         nextcall += 1
 
     def test_termination_with_random_data(self):  # pylint: disable=invalid-name
-        # pylint: enable=invalid-name
         """Test with a random stream of bytes to ensure that the parsing code
         termates and returns, i.e. does not go into any infinite loops.
         """


### PR DESCRIPTION
I disabled the pylint test warnings instead of fixing them because I think most (if not all) had good, consistent naming conventions that weren't worth changing.

Fixes the following `pylint` errors:

```
************* Module test_MIDIMessage_unittests
Error: tests/test_MIDIMessage_unittests.py:36:4: C0103: Method name "test_NoteOn_basic" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
Error: tests/test_MIDIMessage_unittests.py:52:4: C0103: Method name "test_NoteOn_awaitingthirdbyte" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
Error: tests/test_MIDIMessage_unittests.py:73:4: C0103: Method name "test_NoteOn_predatajunk" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
Error: tests/test_MIDIMessage_unittests.py:93:4: C0103: Method name "test_NoteOn_prepartialsysex" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
Error: tests/test_MIDIMessage_unittests.py:130:4: C0103: Method name "test_NoteOn_postNoteOn" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
Error: tests/test_MIDIMessage_unittests.py:146:4: C0103: Method name "test_NoteOn_postpartialNoteOn" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
Error: tests/test_MIDIMessage_unittests.py:162:4: C0103: Method name "test_NoteOn_preotherchannel" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
Error: tests/test_MIDIMessage_unittests.py:178:4: C0103: Method name "test_NoteOn_preotherchannelplusintermediatejunk" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
Error: tests/test_MIDIMessage_unittests.py:198:4: C0103: Method name "test_NoteOn_wrongchannel" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
Error: tests/test_MIDIMessage_unittests.py:211:4: C0103: Method name "test_NoteOn_partialandpreotherchannel1" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
Error: tests/test_MIDIMessage_unittests.py:226:4: C0103: Method name "test_NoteOn_partialandpreotherchannel2" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
Error: tests/test_MIDIMessage_unittests.py:241:4: C0103: Method name "test_NoteOn_constructor_int" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
Error: tests/test_MIDIMessage_unittests.py:267:4: C0103: Method name "test_SystemExclusive_NoteOn" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
Error: tests/test_MIDIMessage_unittests.py:296:4: C0103: Method name "test_SystemExclusive_NoteOn_premalterminatedsysex" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
Error: tests/test_MIDIMessage_unittests.py:314:4: C0103: Method name "test_Unknown_SinglebyteStatus" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
Error: tests/test_MIDIMessage_unittests.py:328:4: C0103: Method name "test_Empty" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
Error: tests/test_MIDIMessage_unittests.py:345:4: C0103: Method name "test_NoteOn_constructor_string" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
Error: tests/test_MIDIMessage_unittests.py:371:4: C0103: Method name "test_NoteOn_constructor_upperrange1" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
Error: tests/test_MIDIMessage_unittests.py:390:4: C0103: Method name "test_NoteOff_constructor_string" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
Error: tests/test_MIDIMessage_unittests.py:420:4: C0103: Method name "test_NoteOff_constructor_upperrange1" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
************* Module test_MIDI_unittests
Error: tests/test_MIDI_unittests.py:39:0: C0103: Function name "MIDI_mocked_both_loopback" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
Error: tests/test_MIDI_unittests.py:63:0: C0103: Function name "MIDI_mocked_receive" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
Error: tests/test_MIDI_unittests.py:103:4: C0103: Method name "test_captured_data_one_byte_reads" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
Error: tests/test_MIDI_unittests.py:175:4: C0103: Method name "test_unknown_before_NoteOn" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
Error: tests/test_MIDI_unittests.py:199:4: C0103: Method name "test_running_status_when_implemented" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
Error: tests/test_MIDI_unittests.py:212:4: C0103: Method name "test_somegood_somemissing_databytes" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
Error: tests/test_MIDI_unittests.py:470:4: C0103: Method name "test_termination_with_random_data" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
```