### PR TITLE
Give all MIDIMessage objects a useful repr()

### DIFF
--- a/adafruit_midi/channel_pressure.py
+++ b/adafruit_midi/channel_pressure.py
@@ -28,7 +28,7 @@ class ChannelPressure(MIDIMessage):
     :param int pressure: The pressure, 0-127.
     """
 
-    _message_slots = ['pressure', 'channel']
+    _message_slots = ["pressure", "channel"]
     _STATUS = 0xD0
     _STATUSMASK = 0xF0
     LENGTH = 2

--- a/adafruit_midi/channel_pressure.py
+++ b/adafruit_midi/channel_pressure.py
@@ -28,6 +28,7 @@ class ChannelPressure(MIDIMessage):
     :param int pressure: The pressure, 0-127.
     """
 
+    _message_slots = ['pressure', 'channel']
     _STATUS = 0xD0
     _STATUSMASK = 0xF0
     LENGTH = 2

--- a/adafruit_midi/control_change.py
+++ b/adafruit_midi/control_change.py
@@ -30,6 +30,7 @@ class ControlChange(MIDIMessage):
 
     """
 
+    _message_slots = ['control', 'value', 'channel']
     _STATUS = 0xB0
     _STATUSMASK = 0xF0
     LENGTH = 3

--- a/adafruit_midi/control_change.py
+++ b/adafruit_midi/control_change.py
@@ -30,7 +30,7 @@ class ControlChange(MIDIMessage):
 
     """
 
-    _message_slots = ['control', 'value', 'channel']
+    _message_slots = ["control", "value", "channel"]
     _STATUS = 0xB0
     _STATUSMASK = 0xF0
     LENGTH = 3

--- a/adafruit_midi/midi_continue.py
+++ b/adafruit_midi/midi_continue.py
@@ -24,6 +24,7 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_MIDI.git"
 
 class Continue(MIDIMessage):
     """Continue MIDI message."""
+
     _message_slots = []
 
     _STATUS = 0xFB

--- a/adafruit_midi/midi_continue.py
+++ b/adafruit_midi/midi_continue.py
@@ -24,6 +24,7 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_MIDI.git"
 
 class Continue(MIDIMessage):
     """Continue MIDI message."""
+    _message_slots = []
 
     _STATUS = 0xFB
     _STATUSMASK = 0xFF

--- a/adafruit_midi/midi_message.py
+++ b/adafruit_midi/midi_message.py
@@ -285,6 +285,18 @@ class MIDIMessage:
         representation of the MIDI message."""
         return cls()
 
+    def __str__(self):
+        """Print an instance"""
+        cls = self.__class__
+        if slots := getattr(cls, '_message_slots', None):
+            args = ", ".join(f"{name}={repr(getattr(self, name, None))}"
+                for name in slots)
+        else:
+            args = "..."
+        return f"{self.__class__.__name__}({args})"
+
+    __repr__ = __str__
+
 
 # DO NOT try to register these messages
 class MIDIUnknownEvent(MIDIMessage):
@@ -296,6 +308,7 @@ class MIDIUnknownEvent(MIDIMessage):
     or because it is not imported.
     """
 
+    _message_slots = ['status']
     LENGTH = -1
 
     def __init__(self, status):
@@ -315,6 +328,8 @@ class MIDIBadEvent(MIDIMessage):
     """
 
     LENGTH = -1
+
+    _message_slots = ['msg_bytes', 'exception']
 
     def __init__(self, msg_bytes, exception):
         self.data = bytes(msg_bytes)

--- a/adafruit_midi/midi_message.py
+++ b/adafruit_midi/midi_message.py
@@ -288,9 +288,11 @@ class MIDIMessage:
     def __str__(self):
         """Print an instance"""
         cls = self.__class__
-        if slots := getattr(cls, '_message_slots', None):
-            args = ", ".join(f"{name}={repr(getattr(self, name, None))}"
-                for name in slots)
+        if slots := getattr(cls, "_message_slots", None):
+            # pylint: disable=not-an-iterable
+            args = ", ".join(
+                f"{name}={repr(getattr(self, name, None))}" for name in slots
+            )
         else:
             args = "..."
         return f"{self.__class__.__name__}({args})"
@@ -308,7 +310,7 @@ class MIDIUnknownEvent(MIDIMessage):
     or because it is not imported.
     """
 
-    _message_slots = ['status']
+    _message_slots = ["status"]
     LENGTH = -1
 
     def __init__(self, status):
@@ -329,7 +331,7 @@ class MIDIBadEvent(MIDIMessage):
 
     LENGTH = -1
 
-    _message_slots = ['msg_bytes', 'exception']
+    _message_slots = ["msg_bytes", "exception"]
 
     def __init__(self, msg_bytes, exception):
         self.data = bytes(msg_bytes)

--- a/adafruit_midi/mtc_quarter_frame.py
+++ b/adafruit_midi/mtc_quarter_frame.py
@@ -41,6 +41,8 @@ class MtcQuarterFrame(MIDIMessage):
     :param value: The quarter frame value for the specified type.
     """
 
+    _message_slots = ['msgtype', 'value']
+
     _STATUS = 0xF1
     _STATUSMASK = 0xFF
     LENGTH = 2

--- a/adafruit_midi/mtc_quarter_frame.py
+++ b/adafruit_midi/mtc_quarter_frame.py
@@ -41,7 +41,7 @@ class MtcQuarterFrame(MIDIMessage):
     :param value: The quarter frame value for the specified type.
     """
 
-    _message_slots = ['msgtype', 'value']
+    _message_slots = ["msgtype", "value"]
 
     _STATUS = 0xF1
     _STATUSMASK = 0xFF

--- a/adafruit_midi/note_off.py
+++ b/adafruit_midi/note_off.py
@@ -31,7 +31,7 @@ class NoteOff(MIDIMessage):  # pylint: disable=duplicate-code
 
     """
 
-    _message_slots = ['note', 'velocity', 'channel']
+    _message_slots = ["note", "velocity", "channel"]
     _STATUS = 0x80
     _STATUSMASK = 0xF0
     LENGTH = 3

--- a/adafruit_midi/note_off.py
+++ b/adafruit_midi/note_off.py
@@ -31,6 +31,7 @@ class NoteOff(MIDIMessage):  # pylint: disable=duplicate-code
 
     """
 
+    _message_slots = ['note', 'velocity', 'channel']
     _STATUS = 0x80
     _STATUSMASK = 0xF0
     LENGTH = 3

--- a/adafruit_midi/note_on.py
+++ b/adafruit_midi/note_on.py
@@ -31,7 +31,7 @@ class NoteOn(MIDIMessage):
         to a Note Off, defaults to 127.
     """
 
-    _message_slots = ['note', 'velocity', 'channel']
+    _message_slots = ["note", "velocity", "channel"]
 
     _STATUS = 0x90
     _STATUSMASK = 0xF0

--- a/adafruit_midi/note_on.py
+++ b/adafruit_midi/note_on.py
@@ -31,6 +31,8 @@ class NoteOn(MIDIMessage):
         to a Note Off, defaults to 127.
     """
 
+    _message_slots = ['note', 'velocity', 'channel']
+
     _STATUS = 0x90
     _STATUSMASK = 0xF0
     LENGTH = 3

--- a/adafruit_midi/pitch_bend.py
+++ b/adafruit_midi/pitch_bend.py
@@ -29,6 +29,7 @@ class PitchBend(MIDIMessage):
         bend from 0 through 8192 (midpoint, no bend) to 16383.
     """
 
+    _message_slots = ['pitch_bend', 'channel']
     _STATUS = 0xE0
     _STATUSMASK = 0xF0
     LENGTH = 3

--- a/adafruit_midi/pitch_bend.py
+++ b/adafruit_midi/pitch_bend.py
@@ -29,7 +29,7 @@ class PitchBend(MIDIMessage):
         bend from 0 through 8192 (midpoint, no bend) to 16383.
     """
 
-    _message_slots = ['pitch_bend', 'channel']
+    _message_slots = ["pitch_bend", "channel"]
     _STATUS = 0xE0
     _STATUSMASK = 0xF0
     LENGTH = 3

--- a/adafruit_midi/polyphonic_key_pressure.py
+++ b/adafruit_midi/polyphonic_key_pressure.py
@@ -30,6 +30,7 @@ class PolyphonicKeyPressure(MIDIMessage):
     :param int pressure: The pressure, 0-127.
     """
 
+    _message_slots = ['note', 'pressure', 'channel']
     _STATUS = 0xA0
     _STATUSMASK = 0xF0
     LENGTH = 3

--- a/adafruit_midi/polyphonic_key_pressure.py
+++ b/adafruit_midi/polyphonic_key_pressure.py
@@ -30,7 +30,7 @@ class PolyphonicKeyPressure(MIDIMessage):
     :param int pressure: The pressure, 0-127.
     """
 
-    _message_slots = ['note', 'pressure', 'channel']
+    _message_slots = ["note", "pressure", "channel"]
     _STATUS = 0xA0
     _STATUSMASK = 0xF0
     LENGTH = 3

--- a/adafruit_midi/program_change.py
+++ b/adafruit_midi/program_change.py
@@ -28,6 +28,7 @@ class ProgramChange(MIDIMessage):
     :param int patch: The new program/patch number to use, 0-127.
     """
 
+    _message_slots = ['patch', 'channel']
     _STATUS = 0xC0
     _STATUSMASK = 0xF0
     LENGTH = 2

--- a/adafruit_midi/program_change.py
+++ b/adafruit_midi/program_change.py
@@ -28,7 +28,7 @@ class ProgramChange(MIDIMessage):
     :param int patch: The new program/patch number to use, 0-127.
     """
 
-    _message_slots = ['patch', 'channel']
+    _message_slots = ["patch", "channel"]
     _STATUS = 0xC0
     _STATUSMASK = 0xF0
     LENGTH = 2

--- a/adafruit_midi/start.py
+++ b/adafruit_midi/start.py
@@ -28,6 +28,7 @@ class Start(MIDIMessage):
     _STATUS = 0xFA
     _STATUSMASK = 0xFF
     LENGTH = 1
-    _message_slots=[]
+    _message_slots = []
+
 
 Start.register_message_type()

--- a/adafruit_midi/start.py
+++ b/adafruit_midi/start.py
@@ -28,6 +28,6 @@ class Start(MIDIMessage):
     _STATUS = 0xFA
     _STATUSMASK = 0xFF
     LENGTH = 1
-
+    _message_slots=[]
 
 Start.register_message_type()

--- a/adafruit_midi/stop.py
+++ b/adafruit_midi/stop.py
@@ -28,6 +28,6 @@ class Stop(MIDIMessage):
     _STATUS = 0xFC
     _STATUSMASK = 0xFF
     LENGTH = 1
-
+    _message_slots=[]
 
 Stop.register_message_type()

--- a/adafruit_midi/stop.py
+++ b/adafruit_midi/stop.py
@@ -28,6 +28,7 @@ class Stop(MIDIMessage):
     _STATUS = 0xFC
     _STATUSMASK = 0xFF
     LENGTH = 1
-    _message_slots=[]
+    _message_slots = []
+
 
 Stop.register_message_type()

--- a/adafruit_midi/system_exclusive.py
+++ b/adafruit_midi/system_exclusive.py
@@ -32,7 +32,7 @@ class SystemExclusive(MIDIMessage):
     This message can only be parsed if it fits within the input buffer in :class:MIDI.
     """
 
-    _message_slots = ['manufacturer_id', 'data']
+    _message_slots = ["manufacturer_id", "data"]
     _STATUS = 0xF0
     _STATUSMASK = 0xFF
     LENGTH = -1

--- a/adafruit_midi/system_exclusive.py
+++ b/adafruit_midi/system_exclusive.py
@@ -32,6 +32,7 @@ class SystemExclusive(MIDIMessage):
     This message can only be parsed if it fits within the input buffer in :class:MIDI.
     """
 
+    _message_slots = ['manufacturer_id', 'data']
     _STATUS = 0xF0
     _STATUSMASK = 0xFF
     LENGTH = -1

--- a/adafruit_midi/timing_clock.py
+++ b/adafruit_midi/timing_clock.py
@@ -34,6 +34,6 @@ class TimingClock(MIDIMessage):
     _STATUS = 0xF8
     _STATUSMASK = 0xFF
     LENGTH = 1
-
+    _slots = []
 
 TimingClock.register_message_type()

--- a/adafruit_midi/timing_clock.py
+++ b/adafruit_midi/timing_clock.py
@@ -36,4 +36,5 @@ class TimingClock(MIDIMessage):
     LENGTH = 1
     _slots = []
 
+
 TimingClock.register_message_type()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,9 +4,9 @@
 #
 # SPDX-License-Identifier: MIT
 
+import datetime
 import os
 import sys
-import datetime
 
 sys.path.insert(0, os.path.abspath(".."))
 

--- a/examples/midi_inoutdemo.py
+++ b/examples/midi_inoutdemo.py
@@ -6,6 +6,8 @@
 import usb_midi
 
 import adafruit_midi
+
+# pylint: disable=unused-import
 from adafruit_midi.channel_pressure import ChannelPressure
 from adafruit_midi.control_change import ControlChange
 from adafruit_midi.midi_message import MIDIUnknownEvent
@@ -17,8 +19,6 @@ from adafruit_midi.program_change import ProgramChange
 from adafruit_midi.start import Start
 from adafruit_midi.stop import Stop
 from adafruit_midi.system_exclusive import SystemExclusive
-
-# pylint: disable=unused-import
 from adafruit_midi.timing_clock import TimingClock
 
 # TimingClock is worth importing first if present as it

--- a/examples/midi_inoutdemo.py
+++ b/examples/midi_inoutdemo.py
@@ -4,16 +4,11 @@
 # midi_inoutdemo - demonstrates receiving and sending MIDI events
 
 import usb_midi
+
 import adafruit_midi
-
-# TimingClock is worth importing first if present as it
-# will make parsing more efficient for this high frequency event
-# Only importing what is used will save a little bit of memory
-
-# pylint: disable=unused-import
-from adafruit_midi.timing_clock import TimingClock
 from adafruit_midi.channel_pressure import ChannelPressure
 from adafruit_midi.control_change import ControlChange
+from adafruit_midi.midi_message import MIDIUnknownEvent
 from adafruit_midi.note_off import NoteOff
 from adafruit_midi.note_on import NoteOn
 from adafruit_midi.pitch_bend import PitchBend
@@ -23,7 +18,13 @@ from adafruit_midi.start import Start
 from adafruit_midi.stop import Stop
 from adafruit_midi.system_exclusive import SystemExclusive
 
-from adafruit_midi.midi_message import MIDIUnknownEvent
+# pylint: disable=unused-import
+from adafruit_midi.timing_clock import TimingClock
+
+# TimingClock is worth importing first if present as it
+# will make parsing more efficient for this high frequency event
+# Only importing what is used will save a little bit of memory
+
 
 midi = adafruit_midi.MIDI(
     midi_in=usb_midi.ports[0],

--- a/examples/midi_intest1.py
+++ b/examples/midi_intest1.py
@@ -2,12 +2,10 @@
 # SPDX-License-Identifier: MIT
 
 import time
-import usb_midi
-import adafruit_midi
 
-# A subset of messages/events
-# pylint: disable=unused-import
-from adafruit_midi.timing_clock import TimingClock
+import usb_midi
+
+import adafruit_midi
 
 # from adafruit_midi.channel_pressure        import ChannelPressure
 from adafruit_midi.control_change import ControlChange
@@ -15,23 +13,19 @@ from adafruit_midi.note_off import NoteOff
 from adafruit_midi.note_on import NoteOn
 from adafruit_midi.pitch_bend import PitchBend
 
+# A subset of messages/events
+# pylint: disable=unused-import
+from adafruit_midi.timing_clock import TimingClock
 
 # 0 is MIDI channel 1
 midi = adafruit_midi.MIDI(midi_in=usb_midi.ports[0], in_channel=0)
 
-print("Midi input test with pauses")
+print("Midi input test")
 
 # Convert channel numbers at the presentation layer to the ones musicians use
 print("Input channel:", midi.in_channel + 1)
 
-# play with the pause to simulate code doing other stuff
-# in the loop
-pauses = [0] * 10 + [0.010] * 10 + [0.100] * 10 + [1.0] * 10
-
 while True:
-    for pause in pauses:
-        msg = midi.receive()
-        if msg is not None:
-            print(time.monotonic(), msg)
-        if pause:
-            time.sleep(pause)
+    msg = midi.receive()
+    if msg is not None:
+        print(time.monotonic(), msg)

--- a/examples/midi_intest1.py
+++ b/examples/midi_intest1.py
@@ -7,14 +7,12 @@ import usb_midi
 
 import adafruit_midi
 
+# pylint: disable=unused-import
 # from adafruit_midi.channel_pressure        import ChannelPressure
 from adafruit_midi.control_change import ControlChange
 from adafruit_midi.note_off import NoteOff
 from adafruit_midi.note_on import NoteOn
 from adafruit_midi.pitch_bend import PitchBend
-
-# A subset of messages/events
-# pylint: disable=unused-import
 from adafruit_midi.timing_clock import TimingClock
 
 # 0 is MIDI channel 1

--- a/examples/midi_memorycheck.py
+++ b/examples/midi_memorycheck.py
@@ -10,9 +10,9 @@
 #
 # E:  8,21: Module 'gc' has no 'mem_free' member (no-member)
 
-import time
-import random
 import gc
+import random
+import time
 
 gc.collect()
 print(gc.mem_free())

--- a/examples/midi_simpletest.py
+++ b/examples/midi_simpletest.py
@@ -1,9 +1,11 @@
 # SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
 # SPDX-License-Identifier: MIT
 # simple_test
-import time
 import random
+import time
+
 import usb_midi
+
 import adafruit_midi
 from adafruit_midi.control_change import ControlChange
 from adafruit_midi.note_off import NoteOff

--- a/tests/test_MIDIMessage_unittests.py
+++ b/tests/test_MIDIMessage_unittests.py
@@ -4,10 +4,8 @@
 
 # pylint: disable=invalid-name
 
-import unittest
-
-
 import os
+import unittest
 
 verbose = int(os.getenv("TESTVERBOSE", "2"))
 

--- a/tests/test_MIDI_unittests.py
+++ b/tests/test_MIDI_unittests.py
@@ -4,11 +4,10 @@
 
 # pylint: disable=invalid-name
 
+import os
+import random
 import unittest
 from unittest.mock import Mock, call
-
-import random
-import os
 
 verbose = int(os.getenv("TESTVERBOSE", "2"))
 
@@ -21,6 +20,9 @@ import sys
 # Borrowing the dhalbert/tannewt technique from adafruit/Adafruit_CircuitPython_Motor
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+# Import after messages - opposite to other test file
+import adafruit_midi
+
 # Full monty
 from adafruit_midi.channel_pressure import ChannelPressure
 from adafruit_midi.control_change import ControlChange
@@ -28,9 +30,6 @@ from adafruit_midi.note_off import NoteOff
 from adafruit_midi.note_on import NoteOn
 from adafruit_midi.pitch_bend import PitchBend
 from adafruit_midi.system_exclusive import SystemExclusive
-
-# Import after messages - opposite to other test file
-import adafruit_midi
 
 # pylint: enable=wrong-import-position
 

--- a/tests/test_note_parser.py
+++ b/tests/test_note_parser.py
@@ -2,9 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
-import unittest
-
 import os
+import unittest
 
 verbose = int(os.getenv("TESTVERBOSE", "2"))
 


### PR DESCRIPTION
For example,
```
>>> from adafruit_midi.note_on import NoteOn
>>> NoteOn(3)
NoteOn(note=3, velocity=127, channel=None)
```