### PR TITLE
Add ActiveSensing message

### DIFF
--- a/adafruit_midi/active_sensing.py
+++ b/adafruit_midi/active_sensing.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2024 Matthew Badeau
+#
+# SPDX-License-Identifier: MIT
+
+"""
+`adafruit_midi.active_sensing`
+================================================================================
+
+Active Sensing MIDI message.
+
+
+* Author(s): Matthew Badeau
+
+Implementation Notes
+--------------------
+
+"""
+
+from .midi_message import MIDIMessage
+
+__version__ = "0.0.0+auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_MIDI.git"
+
+
+class ActiveSensing(MIDIMessage):
+    """Active Sensing MIDI message.
+
+    Active Sensing message is a keepalive message sent every 300 milliseconds
+    to tell the bus that the session is still good and alive.
+    """
+
+    _STATUS = 0xFE
+    _STATUSMASK = 0xFF
+    LENGTH = 1
+    _slots = []
+
+
+ActiveSensing.register_message_type()


### PR DESCRIPTION
I have a Yamaha keyboard hooked up over MIDI UART and is sending the ActiveSensing message a lot. I added it as a valid message.

https://midi.org/expanded-midi-1-0-messages-list

From this [this source](http://midi.teragonaudio.com/tech/midispec/sense.htm), most devices don't implement this feature but I added it anyway.