### PR TITLE
Add active sensing to api docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -7,6 +7,9 @@
 .. automodule:: adafruit_midi
    :members:
 
+.. automodule:: adafruit_midi.active_sensing
+    :members:
+
 .. automodule:: adafruit_midi.channel_pressure
       :members:
 


### PR DESCRIPTION
This is a followup to #57. In that PR @matthewbadeau attempted to add the new feature to the api.rst file but it tripped up the actions check. 

Looking back in the actions failure log it looks like it was just the end of file newline check that failed so adding an extra empty line should be all that's needed to fix I think.

This PR adds it back, and moved it to the beginning of the list which appeared to be in alphabetical order.